### PR TITLE
Fix AppImage generation

### DIFF
--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -10,7 +10,8 @@ strip CmWidget1
 ldd CmWidget1
 
 # Now try to build an AppImage
-mkdir AppDir ; cpCmWidget1  AppDir/
+mkdir AppDir
+cp cpCmWidget1  AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -6,12 +6,12 @@ echo "Inside build-linux.sh"
 qmake -project
 qmake CmWidget1.pro
 make
-strip CmWidget1
-ldd CmWidget1
 
-# Now try to build an AppImage
+# Binary must be inside a directory to be bundled
 mkdir CmWidget
 cp CmWidget1 CmWidget/
+
+# Get linuxdeployqt tool
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
@@ -19,7 +19,7 @@ chmod +x linuxdeployqt
 sudo ln -s /usr/lib/x86_64-linux-gnu/qt5/plugins /usr/lib/plugins
 
 # Have linuxdeployqt create the AppImage
-./linuxdeployqt CmWidget/CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
+./linuxdeployqt CmWidget/CmWidget1 -appimage -bundle-non-qt-libs -verbose=2
 
-find CmWidget/
-ls
+# Upload (replace this with your deployment mechanism)
+curl --upload-file ./CmWidget.AppImage https://transfer.sh/CmWidget.AppImage

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -15,8 +15,4 @@ cp cpCmWidget1  AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
-./linuxdeployqt AppDir/CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
-
-ls -la
-mv ..AppImage CmWidget1.AppImage
-du -sch CmWidget1.AppImage
+./linuxdeployqt $(realpath AppDir/CmWidget1) -appimage -bundle-non-qt-libs -verbose=3

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -10,13 +10,16 @@ strip CmWidget1
 ldd CmWidget1
 
 # Now try to build an AppImage
-mkdir AppDir
-cp CmWidget1 AppDir/
+mkdir CmWidget
+cp CmWidget1 CmWidget/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
-# Work around a bug in linuxdeployqt not being able to bundle system Qt's plugins
+# Work around https://github.com/probonopd/linuxdeployqt/issues/28
 sudo ln -s /usr/lib/x86_64-linux-gnu/qt5/plugins /usr/lib/plugins
 
 # Have linuxdeployqt create the AppImage
-./linuxdeployqt CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
+./linuxdeployqt CmWidget/CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
+
+find CmWidget/
+ls

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -11,9 +11,8 @@ ldd CmWidget1
 
 # Now try to build an AppImage
 mkdir AppDir
-cp cpCmWidget1  AppDir/
+cp CmWidget1 AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
-sudo apt-get -y install realpath
-./linuxdeployqt $(realpath AppDir/CmWidget1) -appimage -bundle-non-qt-libs -verbose=3
+./linuxdeployqt CmWidget1 -appimage -bundle-non-qt-libs -verbose=3

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -15,4 +15,8 @@ cp CmWidget1 AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
+# Work around a bug in linuxdeployqt not being able to bundle system Qt's plugins
+sudo ln -s /usr/lib/x86_64-linux-gnu/qt5/plugins /usr/lib/plugins
+
+# Have linuxdeployqt create the AppImage
 ./linuxdeployqt CmWidget1 -appimage -bundle-non-qt-libs -verbose=3

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -14,7 +14,7 @@ ls -la
 chmod +x linuxdeployqt.AppImage
 ldd CmWidget1
 export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu":$LD_LIBRARY_PATH
-./linuxdeployqt.AppImage CmWidget1 -appimage
+./linuxdeployqt.AppImage CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
 
 ls -la
 mv ..AppImage CmWidget1.AppImage

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -15,4 +15,5 @@ cp cpCmWidget1  AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 
+sudo apt-get -y install realpath
 ./linuxdeployqt $(realpath AppDir/CmWidget1) -appimage -bundle-non-qt-libs -verbose=3

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -10,7 +10,7 @@ strip CmWidget1
 ldd CmWidget1
 
 # Now try to build an AppImage
-mkdir AppDir ; cp AppDir/CmWidget1
+mkdir AppDir ; cpCmWidget1  AppDir/
 wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
 chmod +x linuxdeployqt
 

--- a/ci/ci-build-linux.sh
+++ b/ci/ci-build-linux.sh
@@ -6,15 +6,15 @@ echo "Inside build-linux.sh"
 qmake -project
 qmake CmWidget1.pro
 make
+strip CmWidget1
+ldd CmWidget1
 
 # Now try to build an AppImage
-pwd
-wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt.AppImage
-ls -la
-chmod +x linuxdeployqt.AppImage
-ldd CmWidget1
-export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu":$LD_LIBRARY_PATH
-./linuxdeployqt.AppImage CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
+mkdir AppDir ; cp AppDir/CmWidget1
+wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage -O linuxdeployqt
+chmod +x linuxdeployqt
+
+./linuxdeployqt AppDir/CmWidget1 -appimage -bundle-non-qt-libs -verbose=3
 
 ls -la
 mv ..AppImage CmWidget1.AppImage


### PR DESCRIPTION
This PR, when merged, will fix the AppImage generation.

The AppImage will look like this one:
https://transfer.sh/5rX27/cmwidget.appimage

**NOTE:** There is still a mysterious bug that seems to cripple the binary inside the AppImage, resulting in `: symbol , version  not defined in file  with link time reference` when executing it. I [filed a linuxdeployqt bug](https://github.com/probonopd/linuxdeployqt/issues/29) for this.

Please enable [commit squashing](https://github.com/blog/2141-squash-your-commits) before merging, and remove the transfer.sh upload with your mechanism for deployment.